### PR TITLE
Don't hardcode localhost

### DIFF
--- a/lib/webpack/rails/manifest.rb
+++ b/lib/webpack/rails/manifest.rb
@@ -54,7 +54,7 @@ module Webpack
 
         def load_dev_server_manifest
           http = Net::HTTP.new(
-            "localhost",
+            ::Rails.configuration.webpack.dev_server.host,
             ::Rails.configuration.webpack.dev_server.port)
           http.use_ssl = ::Rails.configuration.webpack.dev_server.https
           http.verify_mode = OpenSSL::SSL::VERIFY_NONE
@@ -81,7 +81,7 @@ module Webpack
         end
 
         def dev_server_url
-          "http://localhost:#{::Rails.configuration.webpack.dev_server.port}#{dev_server_path}"
+          "http://#{::Rails.configuration.webpack.dev_server.host}:#{::Rails.configuration.webpack.dev_server.port}#{dev_server_path}"
         end
       end
     end


### PR DESCRIPTION
In the Railtie, a facility is provided to specify the host where the dev server is running. In fact, this configuration value is used in the `webpack_asset_paths` helper. This pull request replaces the hardcoded `localhost` with `::Rails.configuration.webpack.dev_server.host` in the manifest.

This comes in handy when we're running the dev server in a docker container, and need to pass the host name in. For linux, it may well be `localhost`. However, for Docker for Mac (beta), this needs to be `docker.local`. For docker-machine users, unless they are running their own local dns, this would be an IP address.
